### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN yarn run build
 
 # Production image - copy only what's needed
 FROM base AS runner
+
+LABEL org.opencontainers.image.source=https://github.com/icco/realworldsre.com
+LABEL org.opencontainers.image.description="Marketing site for book"
+LABEL org.opencontainers.image.licenses=MIT
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)